### PR TITLE
Ref #119 - Add zoom button on chart

### DIFF
--- a/src/js/components/charts/barChart.js
+++ b/src/js/components/charts/barChart.js
@@ -14,6 +14,27 @@ import {
 export default class BarChart {
   constructor(element) {
     const canvas = element.querySelector('canvas')
+    const resetBtn = element.querySelector('[data-role=reset]')
+    const zoomInBtn = element.querySelector('[data-role=zoom-in]')
+    const zoomOutBtn = element.querySelector('[data-role=zoom-out]')
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', () => {
+        ChartInstance.resetZoom()
+      })
+    }
+
+    if (zoomInBtn) {
+      zoomInBtn.addEventListener('click', () => {
+        ChartInstance.zoomIn()
+      })
+    }
+
+    if (zoomOutBtn) {
+      zoomOutBtn.addEventListener('click', () => {
+        ChartInstance.zoomOut()
+      })
+    }
 
     // data
     const labels = element.dataset.labels ? JSON.parse(element.dataset.labels) : []
@@ -36,7 +57,7 @@ export default class BarChart {
       dataCounter += 1
     })
 
-    new Chart(canvas, {
+    const ChartInstance = new Chart(canvas, {
       type: 'bar',
       data: barChartData,
       options: {
@@ -70,6 +91,7 @@ export default class BarChart {
         },
         zoom: {
           enabled: true,
+          drag: true,
           mode: 'xy'
         }
       }

--- a/templates/intern/4.0/components/charts.md
+++ b/templates/intern/4.0/components/charts.md
@@ -79,6 +79,9 @@ ee measurements per bar. In proportional bar graphs, all bars are the same size 
         </ul>
     </div>
     <canvas></canvas>
+    <button type="button" data-role="reset">Reset</button>
+    <button type="button" data-role="zoom-in">Zoom in</button>
+    <button type="button" data-role="zoom-out">Zoom out</button>
 </div>
 {% endexample html %}
 


### PR DESCRIPTION
#WIP

Les boutons ne sont pas stylisés, la fonction fonctionne mais demande de fork la librairie (je n'ai pas encore push sur mon repo).
Je ne trouve pas ça très utilisable, le zoom avec souris se base sur la position de la sourie. Avec les boutons je dois définir où est-ce que le zoom s'effectue.