### PR TITLE
Ref #147 - Fix datetime picker on mobile

### DIFF
--- a/src/js/components/picker.js
+++ b/src/js/components/picker.js
@@ -16,8 +16,7 @@ const DEFAULT_OPTIONS = {
   /* eslint-disable camelcase */
   time_24hr: true,
   /* eslint-enable camelcase */
-  /* Désactivation de l'appel au calendrier natif */
-  disableMobile: true
+  disableMobile: false
 }
 
 /**


### PR DESCRIPTION
Ref #147 

J'ai mis à jour le repos distant, normalement ça corrige le problème.
Faire un `yarn install` du coup, ou `yarn install https://github.com/vdesdoigts/flatpickr.git#dist`