### PR TITLE
Update accessibility

### DIFF
--- a/src/js/components/picker.js
+++ b/src/js/components/picker.js
@@ -41,6 +41,7 @@ class Picker {
     const decrementHoursOnMinutesMin = element.getAttribute('data-decrement-hours-on-minutes-min') || false
     const plugins = []
     const onOpen = []
+    const onReady = []
 
     if (secondRangeInput) {
       /* eslint-disable new-cap */
@@ -62,6 +63,12 @@ class Picker {
     if (mode === 'time' || timePicker) {
       options.enableTime = true
       options.noCalendar = true
+      onReady.push(
+        () => {
+          element.nextSibling.querySelector('.flatpickr-hour').setAttribute('title', 'Sélectionnez l\'heure')
+          element.nextSibling.querySelector('.flatpickr-minute').setAttribute('title', 'Sélectionnez la minute')
+        }
+      )
     }
 
     if (enableTime) {
@@ -77,7 +84,10 @@ class Picker {
     }
 
     onOpen.push(
-      () => btnNode.classList.add('active')
+      () => {
+        btnNode.classList.add('active')
+        btnNode.setAttribute('aria-expanded', 'true')
+      }
     )
 
     element.flatpickr = flatpickr(element, {
@@ -86,7 +96,9 @@ class Picker {
       onOpen,
       onClose: () => {
         btnNode.classList.remove('active')
-      }
+        btnNode.setAttribute('aria-expanded', 'false')
+      },
+      onReady
     })
   }
 

--- a/src/js/components/selectMultiple.js
+++ b/src/js/components/selectMultiple.js
@@ -126,10 +126,12 @@ class SelectMultiple {
       this.store[groupId].currentValues.push(valueId)
       this.count.currentValues += 1
       valueNode.classList.add(ACTIVE_CLASS)
+      valueNode.setAttribute('aria-checked', 'true')
     } else {
       pull(this.store[groupId].currentValues, valueId)
       this.count.currentValues -= 1
       valueNode.classList.remove(ACTIVE_CLASS)
+      valueNode.setAttribute('aria-checked', 'false')
     }
 
     this._updatePlaceholderNodeStyle()

--- a/src/scss/common/components/_select.scss
+++ b/src/scss/common/components/_select.scss
@@ -105,15 +105,21 @@ $select-scrollable-max-height: rem(360px);
 }
 
 .select-menu-item {
+  display: block;
   width: 100%;
-  padding: 0;
+  padding: 0; // legacy
   font-weight: $font-weight-medium;
   color: gray("500");
   text-align: left;
   cursor: pointer;
-  background: none;
-  border: 0;
+  background: none; // legacy
+  border: 0; // legacy
 
+  + .select-menu-item {
+    margin-top: rem(14px);
+  }
+
+  // legacy
   &:hover,
   &:focus,
   &:active,
@@ -121,9 +127,26 @@ $select-scrollable-max-height: rem(360px);
     color: theme-color("primary");
   }
 
-  + .select-menu-item {
-    margin-top: rem(14px);
+  // stylelint-disable selector-no-qualifying-type
+  > button,
+  > a {
+    display: block;
+    width: 100%;
+    padding: 0;
+    font-weight: $font-weight-medium;
+    color: currentColor;
+    text-align: left;
+    background: none;
+    border: 0;
+
+    &:hover,
+    &:focus,
+    &:active,
+    &.active {
+      color: theme-color("primary");
+    }
   }
+  // stylelint-enable selector-no-qualifying-type
 }
 
 .select-group {

--- a/templates/_includes/components/select-exclusive.html
+++ b/templates/_includes/components/select-exclusive.html
@@ -17,7 +17,7 @@
     <div class="select-menu" id="{{ item.id }}-selecttoggle">
       <div class="d-flex flex-column">
         <div class="flex-fluid overflow-y" role="list" data-role="menu">
-          {% for item in include.items %}<button class="select-menu-item" role="listitem" data-role="value" data-target="{{ forloop.index }}">{{ item.name }}</button>
+          {% for item in include.items %}<span class="select-menu-item" role="listitem"><button data-role="value" data-target="{{ forloop.index }}">{{ item.name }}</button></span>
           {% endfor %}
         </div>
         {{- include.content }}

--- a/templates/docs/4.0/components/picker.md
+++ b/templates/docs/4.0/components/picker.md
@@ -20,15 +20,15 @@ Please note that **you don't** have to load `flatpickr.js` since it's already in
 
 ## Date
 {% example html %}
-<label for="dateselect1" class="font-weight-medium mb-2">Date (jj/mm/aaaa)</label>
+<label for="date" class="font-weight-medium mb-2">Date (jj/mm/aaaa)</label>
 <div data-component="picker">
   <div class="input-group" data-toggle>
     <div class="form-control-container">
-      <input id="dateselect1" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
+      <input id="date" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" tabindex="-1">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" tabindex="-1" aria-expanded="false">
         <i class="icons-calendar" aria-hidden="true"></i>
       </button>
     </div>
@@ -41,15 +41,15 @@ Please note that **you don't** have to load `flatpickr.js` since it's already in
 Date-pickers let users select a date (in dd/mm/yyyy format) using a calendar visual. Be sure to visually differentiate the current date (selected by default), the date the user selects, and dates that cannot be selected.
 
 {% example html %}
-<label for="dateselect2" class="font-weight-medium mb-2">Date (jj/mm/aaaa)</label>
+<label for="defaultdate" class="font-weight-medium mb-2">Date (jj/mm/aaaa)</label>
 <div data-component="picker" data-default-date="2017-02-26">
   <div class="input-group" data-toggle>
     <div class="form-control-container">
-      <input id="dateselect2" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
+      <input id="defaultdate" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" tabindex="-1">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" tabindex="-1" aria-expanded="false">
         <i class="icons-calendar" aria-hidden="true"></i>
       </button>
     </div>
@@ -63,15 +63,15 @@ The range-picker lets users select a start date and end date to define a period 
 
 {% example html %}
 <div aria-hidden="true">
-  <label class="font-weight-medium mb-2">Date</label>
+  <label for="range" class="font-weight-medium mb-2">Date</label>
   <div data-component="picker" data-mode="range">
     <div class="input-group" data-toggle>
       <div class="form-control-container">
-        <input tabindex="-1" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
+        <input id="range" tabindex="-1" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
         <span class="form-control-state"></span>
       </div>
       <div class="input-group-append">
-        <button tabindex="-1" type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+        <button tabindex="-1" type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
           <i class="icons-calendar" aria-hidden="true"></i>
         </button>
       </div>
@@ -82,7 +82,7 @@ The range-picker lets users select a start date and end date to define a period 
   <button class="btn-link" aria-controls="inputrange" data-component="state" data-state="d-none" data-behaviour="toggle" data-target=".range-inputs">
     Saisir une plage de date
   </button>
-  <div class="row pt-2 range-inputs d-none" id="inputrange">
+  <div class="row pt-2 range-inputs d-none" id="inputrange" aria-expanded="false">
     <div class="col">
       <div class="form-group">
         <label for="date1">Date d’arrivée (jj/mm/aaaa)</label>
@@ -112,7 +112,7 @@ Time-pickers let users select a time (in hh:mm format) using a clock visual. Be 
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
         <span class="sr-only">Saisir l’heure</span>
         <i class="icons-calendar-time" aria-hidden="true"></i>
       </button>
@@ -134,7 +134,7 @@ Only use a date-time-picker when you need to optimize space and reduce the numbe
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
         <i class="icons-calendar-time" aria-hidden="true"></i>
       </button>
     </div>

--- a/templates/extern/4.0/components/picker.md
+++ b/templates/extern/4.0/components/picker.md
@@ -11,15 +11,15 @@ permalink: /docs/4.0/components/picker/
 Date pickers are often used for forms or for other functional purposes; they let users select a date. The default value is the current date at the time the user opens the calendar. The length of the date-picker field is not fixed, but it must respect the grid.
 
 {% example html %}
-<label class="font-weight-medium mb-2">Date</label>
+<label for="date" class="font-weight-medium mb-2">Date</label>
 <div data-component="picker">
   <div class="input-group input-group--flatpickr">
     <div class="form-control-container" data-toggle>
-      <input type="text" class="form-control" placeholder="Sélectionner une date" data-input>
+      <input id="date" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
         <i class="icons-calendar"></i>
       </button>
     </div>
@@ -30,15 +30,15 @@ Date pickers are often used for forms or for other functional purposes; they let
 ## Default date
 
 {% example html %}
-<label class="font-weight-medium mb-2">Date</label>
+<label for="defaultdate" class="font-weight-medium mb-2">Date</label>
 <div data-component="picker" data-default-date="2017-02-26">
   <div class="input-group input-group--flatpickr">
     <div class="form-control-container" data-toggle>
-      <input type="text" class="form-control" placeholder="Sélectionner une date" data-input>
+      <input id="defaultdate" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
         <i class="icons-calendar"></i>
       </button>
     </div>
@@ -49,17 +49,38 @@ Date pickers are often used for forms or for other functional purposes; they let
 ## Range
 
 {% example html %}
-<label class="font-weight-medium mb-2">Date</label>
-<div data-component="picker" data-mode="range">
-  <div class="input-group input-group--flatpickr">
-    <div class="form-control-container" data-toggle>
-      <input type="text" class="form-control" placeholder="Sélectionner une date" data-input>
-      <span class="form-control-state"></span>
+<div aria-hidden="true">
+  <label for="range" class="font-weight-medium mb-2">Date</label>
+  <div data-component="picker" data-mode="range">
+    <div class="input-group input-group--flatpickr">
+      <div class="form-control-container" data-toggle>
+        <input id="range" type="text" class="form-control" placeholder="Sélectionner une date" data-input>
+        <span class="form-control-state"></span>
+      </div>
+      <div class="input-group-append">
+        <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
+          <i class="icons-calendar"></i>
+        </button>
+      </div>
     </div>
-    <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
-        <i class="icons-calendar"></i>
-      </button>
+  </div>
+</div>
+<div class="pt-3">
+  <button class="btn-link" aria-controls="inputrange" data-component="state" data-state="d-none" data-behaviour="toggle" data-target=".range-inputs">
+    Saisir une plage de date
+  </button>
+  <div class="row pt-2 range-inputs d-none" id="inputrange" aria-expanded="false">
+    <div class="col">
+      <div class="form-group">
+        <label for="date1">Date d’arrivée (jj/mm/aaaa)</label>
+        {% include components/input.html type="text" id="date1" class="form-control" %}
+      </div>
+    </div>
+    <div class="col">
+      <div class="form-group">
+        <label for="date2">Date de départ (jj/mm/aaaa)</label>
+        {% include components/input.html type="text" id="date2" class="form-control" %}
+      </div>
     </div>
   </div>
 </div>
@@ -73,15 +94,15 @@ Time pickers are often used for forms or for other functional purposes; they let
 The length of the time-picker field is not fixed, but it must respect the content grid.
 
 {% example html %}
-<label class="font-weight-medium mb-2">Date</label>
+<label for="timepicker" class="font-weight-medium mb-2">Date</label>
 <div data-component="picker" data-timepicker="true" data-increment-hours-on-minutes-max="true">
   <div class="input-group input-group--flatpickr">
     <div class="form-control-container" data-toggle>
-      <input type="text" class="form-control" placeholder="Sélectionner une heure" data-input>
+      <input id="timepicker" type="text" class="form-control" placeholder="Sélectionner une heure" data-input>
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
         <i class="icons-calendar-time"></i>
       </button>
     </div>
@@ -92,15 +113,15 @@ The length of the time-picker field is not fixed, but it must respect the conten
 ## DateTime picker
 
 {% example html %}
-<label class="font-weight-medium mb-2">Date</label>
+<label for="datetimepicker" class="font-weight-medium mb-2">Date</label>
 <div data-component="picker" data-enable-time="true">
   <div class="input-group input-group--flatpickr">
     <div class="form-control-container" data-toggle>
-      <input type="text" class="form-control" placeholder="Sélectionner une heure" data-input>
+      <input id="datetimepicker" type="text" class="form-control" placeholder="Sélectionner une heure" data-input>
       <span class="form-control-state"></span>
     </div>
     <div class="input-group-append">
-      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn">
+      <button type="button" class="btn btn-primary btn-only-icon" data-role="btn" aria-expanded="false">
         <i class="icons-calendar-time"></i>
       </button>
     </div>

--- a/templates/extern/4.0/components/select.md
+++ b/templates/extern/4.0/components/select.md
@@ -87,9 +87,9 @@ When the list contains very different items, it may be a good idea to group them
           <span class="select-group-title text-uppercase">Unité 1</span>
         </div>
         <div class="select-group-content" role="list">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="0">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="1">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="0">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="1">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button></span>
         </div>
       </div>
       <div role="listitem" class="select-group">
@@ -97,8 +97,8 @@ When the list contains very different items, it may be a good idea to group them
           <span class="select-group-title text-uppercase">Unité 2</span>
         </div>
         <div class="select-group-content" role="list">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="3">Amet Porta</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="4">Pharetra Fusce Venenatis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="3">Amet Porta</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="4">Pharetra Fusce Venenatis</button></span>
         </div>
       </div>
     </div>
@@ -138,9 +138,9 @@ When the list contains very different items, it may be a good idea to group them
           </div>
         </button>
         <div id="collapseExample" role="list" class="collapse select-group-content">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="0">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="1">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="0">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="1">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button></span>
         </div>
       </div>
       <div class="select-group select-group-expand" role="listitem">
@@ -153,8 +153,8 @@ When the list contains very different items, it may be a good idea to group them
           </div>
         </button>
         <div id="collapseExample1" role="list" class="collapse select-group-content">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="3">Amet Porta</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="4">Pharetra Fusce Venenatis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="3">Amet Porta</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="4">Pharetra Fusce Venenatis</button></span>
         </div>
       </div>
     </div>
@@ -192,22 +192,22 @@ Multi-select drop-down lists let users choose multiple options.
       <div class="select-group" data-role="group" data-id="0" role="list">
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="0" class="custom-control-label w-100 text-left font-weight-medium">Sem Inceptos Tellus</button>
+            <button data-role="value" data-target="0" role="checkbox" aria-checked="false" tabindex="0" class="custom-control-label w-100 text-left font-weight-medium">Sem Inceptos Tellus</button>
           </div>
         </div>
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="1" class="custom-control-label w-100 text-left font-weight-medium">Sollicitudin Adipiscing Mattis</button>
+            <button data-role="value" data-target="1" role="checkbox" aria-checked="false" tabindex="0" class="custom-control-label w-100 text-left font-weight-medium">Sollicitudin Adipiscing Mattis</button>
           </div>
         </div>
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="2" class="custom-control-label w-100 text-left font-weight-medium">Amet Porta</button>
+            <button data-role="value" data-target="2" role="checkbox" aria-checked="false" tabindex="0" class="custom-control-label w-100 text-left font-weight-medium">Amet Porta</button>
           </div>
         </div>
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="3" class="custom-control-label w-100 text-left font-weight-medium">Pharetra Fusce Venenatis</button>
+            <button data-role="value" data-target="3" role="checkbox" aria-checked="false" tabindex="0" class="custom-control-label w-100 text-left font-weight-medium">Pharetra Fusce Venenatis</button>
           </div>
         </div>
       </div>

--- a/templates/intern/4.0/components/select.md
+++ b/templates/intern/4.0/components/select.md
@@ -155,9 +155,9 @@ When the list contains very different items, it may be a good idea to group them
           <span class="select-group-title text-uppercase">Unité 1</span>
         </div>
         <div class="select-group-content" role="list">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="0">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="1">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="0">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="1">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button></span>
         </div>
       </div>
       <div role="listitem" class="select-group">
@@ -165,8 +165,8 @@ When the list contains very different items, it may be a good idea to group them
           <span class="select-group-title text-uppercase">Unité 2</span>
         </div>
         <div class="select-group-content" role="list">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="3">Amet Porta</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="4">Pharetra Fusce Venenatis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="3">Amet Porta</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="4">Pharetra Fusce Venenatis</button></span>
         </div>
       </div>
     </div>
@@ -206,9 +206,9 @@ When the list contains very different items, it may be a good idea to group them
           </div>
         </button>
         <div id="collapseExample" role="list" class="collapse select-group-content">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="0">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="1">Sem Inceptos Tellus</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="0">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="1">Sem Inceptos Tellus</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="2">Sollicitudin Adipiscing Mattis</button></span>
         </div>
       </div>
       <div class="select-group select-group-expand" role="listitem">
@@ -221,8 +221,8 @@ When the list contains very different items, it may be a good idea to group them
           </div>
         </button>
         <div id="collapseExample1" role="list" class="collapse select-group-content">
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="3">Amet Porta</button>
-          <button class="select-menu-item" role="listitem" data-role="value" data-target="4">Pharetra Fusce Venenatis</button>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="3">Amet Porta</button></span>
+          <span class="select-menu-item" role="listitem"><button data-role="value" data-target="4">Pharetra Fusce Venenatis</button></span>
         </div>
       </div>
     </div>
@@ -260,22 +260,22 @@ Multi-select drop-down lists let users choose multiple options.
       <div class="select-group" data-role="group" data-id="0" role="list">
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="0" class="custom-control-label w-100 text-left font-weight-medium">Sem Inceptos Tellus</button>
+            <button data-role="value" data-target="0" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Sem Inceptos Tellus</button>
           </div>
         </div>
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="1" class="custom-control-label w-100 text-left font-weight-medium">Sollicitudin Adipiscing Mattis</button>
+            <button data-role="value" data-target="1" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Sollicitudin Adipiscing Mattis</button>
           </div>
         </div>
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="2" class="custom-control-label w-100 text-left font-weight-medium">Amet Porta</button>
+            <button data-role="value" data-target="2" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Amet Porta</button>
           </div>
         </div>
         <div class="select-menu-item" role="listitem">
           <div class="custom-control custom-checkbox">
-            <button data-role="value" data-target="3" class="custom-control-label w-100 text-left font-weight-medium">Pharetra Fusce Venenatis</button>
+            <button data-role="value" data-target="3" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Pharetra Fusce Venenatis</button>
           </div>
         </div>
       </div>
@@ -319,12 +319,12 @@ Multi-select drop-down lists let users choose multiple options.
         <div class="select-group-content" role="list">
           <div class="select-menu-item" role="listitem">
             <div class="custom-control custom-checkbox">
-              <button data-role="value" data-target="0" class="custom-control-label w-100 text-left font-weight-medium">Sem Inceptos Tellus</button>
+              <button data-role="value" data-target="0" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Sem Inceptos Tellus</button>
             </div>
           </div>
           <div class="select-menu-item" role="listitem">
             <div class="custom-control custom-checkbox">
-              <button data-role="value" data-target="1" class="custom-control-label w-100 text-left font-weight-medium">Sollicitudin Adipiscing Mattis</button>
+              <button data-role="value" data-target="1" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Sollicitudin Adipiscing Mattis</button>
             </div>
           </div>
         </div>
@@ -338,12 +338,12 @@ Multi-select drop-down lists let users choose multiple options.
         <div class="select-group-content" role="list">
           <div class="select-menu-item" role="listitem">
             <div class="custom-control custom-checkbox">
-              <button data-role="value" data-target="2" class="custom-control-label w-100 text-left font-weight-medium">Amet Porta</button>
+              <button data-role="value" data-target="2" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Amet Porta</button>
             </div>
           </div>
           <div class="select-menu-item" role="listitem">
             <div class="custom-control custom-checkbox">
-              <button data-role="value" data-target="3" class="custom-control-label w-100 text-left font-weight-medium">Pharetra Fusce Venenatis</button>
+              <button data-role="value" data-target="3" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">Pharetra Fusce Venenatis</button>
             </div>
           </div>
         </div>
@@ -357,7 +357,7 @@ Multi-select drop-down lists let users choose multiple options.
         <div class="select-group-content" role="list">
           <div class="select-menu-item" role="listitem">
             <div class="custom-control custom-checkbox">
-              <button data-role="value" data-target="4" class="custom-control-label w-100 text-left font-weight-medium">En plus</button>
+              <button data-role="value" data-target="4" role="checkbox" aria-checked="false" class="custom-control-label w-100 text-left font-weight-medium">En plus</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Picker

⬜ le readonly est toujours là. J'ai bien vu que vous dites que c'est le script qui l'ajoute mais il faut trouver une méthode pour le supprimer ou rendre les datepicker complètement accessibles.
✅ le champ "date" n'est pas relié à son label (relation for/id à ajouter)
✅ sur le bouton "saisir une plage de date" ajouter la prop aria-expanded 
✅ manque aria-expanded sur le bouton d'ajout de l'heure
✅ sur le bouton "saisir une plage de date" ajouter la prop aria-expanded 
✅ sur le bouton "saisir une plage de date" ajouter la prop aria-expanded
✅ le champ et son étiquette ne sont pas reliés (utilisez la relation for/id)
✅ les champs heures et minutes n'ont pas d'étiquettes (génération CSS interdite, utilisez un attribut title en remédiation à minima)
⬜ pas d'aide à la saisie - **plus d'infos sur le comportement attendu ?**


## Select
✅ manque la structuration en liste : vous avez ajouté les role=listitem directement sur les boutons, il faut les mettre sur un élément container : <span role="listitem"><button></button></span>
✅ vous avez ajouté des button en place des checkbox conseillée. Il faut donc retranscrire l'état sélectionné à l'utilisateur (avec une checkbox le changement d'état est géré nativement).  Une possibilité est de simuler la checkbox avec le DP ARIA correspondant : https://www.w3.org/TR/wai-aria-practices/examples/checkbox/checkbox-1/checkbox-1.html

@nicolaswurtz les modifications que tu as apportés sur les selects apportent quelques soucis, ils en se ferment plus au premier click sur une option.