### PR TITLE
Update flapickr dependency and month selection

### DIFF
--- a/src/scss/common/components/_flatpickr.scss
+++ b/src/scss/common/components/_flatpickr.scss
@@ -159,6 +159,9 @@
 
   .flatpickr-monthDropdown-months {
     flex: 1 1 auto;
+    min-height: auto;
+    padding-right: 0;
+    padding-left: 0;
   }
 
   .numInput.cur-year {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3399,9 +3399,9 @@ flat-cache@^2.0.1:
     write "1.0.3"
 
 flatpickr@^4.6.2:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.3.tgz#15a8b76b6e34e3a072861250503a5995b9d3bc60"
-  integrity sha512-007VucCkqNOMMb9ggRLNuJowwaJcyOh4sKAFcdGfahfGc7JQbf94zSzjdBq/wVyHWUEs5o3+idhFZ0wbZMRmVQ==
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.2.tgz#50e1b4fc84fbf67c5b0919ba3ddc330221f126da"
+  integrity sha512-bRfBPyxohUQWgCTg6jPALUO1t/x+sRJ/S/RVti/NzYvHqGRpCAesKSWKLzOuLmpu+vGHfXBld4SXvOCLFgYb+g==
 
 flatted@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
J'ai mis à jour le datepickr puisqu'il s'avère que les fonctionnalités que j'avais implémenté dans mon fork ont été ajouté au paquet officiel.

J'ai modifié les flèches, pour le moment voici le résultat 👇 
![Capture d’écran 2019-07-30 à 18 00 12](https://user-images.githubusercontent.com/2852794/62145658-1c6a3e80-b2f4-11e9-86f5-891aa952fe79.png)
